### PR TITLE
Update instructions for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ nfd2nfc solves the root cause of filenames breaking across operating systems —
 Requires [Homebrew](https://brew.sh).
 
 ```bash
-brew install elgar328/nfd2nfc/nfd2nfc
+brew install nfd2nfc
 ```
 
 Then run it:


### PR DESCRIPTION
`nfd2nfc` is now [available](https://github.com/Homebrew/homebrew-core/commit/75025aa75d5614c90ec08b328dd5cfab370aba6c) directly via [Homebrew](https://brew.sh).